### PR TITLE
feat: 아바타 컴포넌트 아이콘 기반으로 리디자인

### DIFF
--- a/src/components/Avatar/Avatar.scss
+++ b/src/components/Avatar/Avatar.scss
@@ -4,9 +4,10 @@
 
 .ds-avatar {
   border-radius: $radius-full;
-  background: linear-gradient(135deg, $primary, $secondary);
+  background: $gray-800;
+  border: 1px solid $gray-600;
   @include flex-center;
-  color: white;
+  color: $gray-300;
   font-weight: $font-weight-medium;
   font-family: $font-family;
   position: relative;
@@ -16,6 +17,7 @@
   width: 36px;
   height: 36px;
   font-size: $font-size-base;
+  box-sizing: border-box;
   
   // Sizes
   &--small {
@@ -69,20 +71,27 @@
   
   // Color variants
   &--primary {
-    background: linear-gradient(135deg, $primary, color.adjust($primary, $lightness: -10%));
+    background: $gray-800;
+    color: $gray-300;
+    border-color: $gray-600;
   }
   
   &--secondary {
-    background: linear-gradient(135deg, $secondary, color.adjust($secondary, $lightness: -10%));
+    background: $gray-900;
+    color: $gray-400;
+    border-color: $gray-700;
   }
   
   &--accent {
-    background: linear-gradient(135deg, $accent, color.adjust($accent, $lightness: -15%));
-    color: $gray-200;
+    background: $yellow-300;
+    color: $primary;
+    border-color: rgba($primary, 0.15);
   }
   
   &--gray {
-    background: linear-gradient(135deg, #95a5a6, #7f8c8d);
+    background: $gray-700;
+    color: $gray-50;
+    border-color: $gray-600;
   }
   
   // Interactive

--- a/src/components/Avatar/Avatar.stories.tsx
+++ b/src/components/Avatar/Avatar.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
+import { User, Users, UserCircle, UserSquare, Shield, Crown, Star } from 'lucide-react';
 import Avatar from './Avatar';
 
 const meta: Meta<typeof Avatar> = {
@@ -24,9 +25,6 @@ const meta: Meta<typeof Avatar> = {
     clickable: {
       control: 'boolean',
     },
-    children: {
-      control: 'text',
-    },
     image: {
       control: 'text',
     },
@@ -38,13 +36,12 @@ type Story = StoryObj<typeof Avatar>;
 
 export const Default: Story = {
   args: {
-    children: '김',
+    // 기본값으로 User 아이콘 사용
   },
 };
 
 export const Small: Story = {
   args: {
-    children: '이',
     size: 'small',
     color: 'secondary',
   },
@@ -52,7 +49,6 @@ export const Small: Story = {
 
 export const Large: Story = {
   args: {
-    children: '박',
     size: 'large',
     color: 'accent',
   },
@@ -60,7 +56,6 @@ export const Large: Story = {
 
 export const ExtraLarge: Story = {
   args: {
-    children: '최',
     size: 'xl',
     color: 'primary',
   },
@@ -68,14 +63,12 @@ export const ExtraLarge: Story = {
 
 export const WithStatus: Story = {
   args: {
-    children: '온',
     status: 'online',
   },
 };
 
 export const Away: Story = {
   args: {
-    children: '자',
     status: 'away',
     color: 'secondary',
   },
@@ -83,7 +76,6 @@ export const Away: Story = {
 
 export const Offline: Story = {
   args: {
-    children: '오',
     status: 'offline',
     color: 'gray',
   },
@@ -91,7 +83,6 @@ export const Offline: Story = {
 
 export const Clickable: Story = {
   args: {
-    children: '클',
     clickable: true,
     onClick: () => alert('Avatar clicked!'),
   },
@@ -99,27 +90,46 @@ export const Clickable: Story = {
 
 export const AllSizes = () => (
   <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-    <Avatar size="small">소</Avatar>
-    <Avatar size="medium">중</Avatar>
-    <Avatar size="large">대</Avatar>
-    <Avatar size="xl">특</Avatar>
+    <Avatar size="small" />
+    <Avatar size="medium" />
+    <Avatar size="large" />
+    <Avatar size="xl" />
   </div>
 );
 
 export const AllColors = () => (
   <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
-    <Avatar color="primary">P</Avatar>
-    <Avatar color="secondary">S</Avatar>
-    <Avatar color="accent">A</Avatar>
-    <Avatar color="gray">G</Avatar>
+    <Avatar color="primary" />
+    <Avatar color="secondary" />
+    <Avatar color="accent" />
+    <Avatar color="gray" />
+  </div>
+);
+
+export const DifferentIcons = () => (
+  <div style={{ display: 'flex', alignItems: 'center', gap: '16px' }}>
+    <Avatar icon={User} color="primary" />
+    <Avatar icon={Users} color="secondary" />
+    <Avatar icon={UserCircle} color="accent" />
+    <Avatar icon={UserSquare} color="gray" />
+    <Avatar icon={Shield} color="primary" />
+    <Avatar icon={Crown} color="secondary" />
+    <Avatar icon={Star} color="accent" />
   </div>
 );
 
 export const AvatarGroup = () => (
   <div className="ds-avatar-group">
-    <Avatar color="primary">김</Avatar>
-    <Avatar color="secondary">이</Avatar>
-    <Avatar color="accent">박</Avatar>
-    <Avatar color="gray">+2</Avatar>
+    <Avatar color="primary" icon={User} />
+    <Avatar color="secondary" icon={Users} />
+    <Avatar color="accent" icon={UserCircle} />
+    <Avatar color="gray" icon={Crown} />
   </div>
 );
+
+export const WithImage: Story = {
+  args: {
+    image: 'https://via.placeholder.com/150',
+    alt: 'User Avatar',
+  },
+};

--- a/src/components/Avatar/Avatar.tsx
+++ b/src/components/Avatar/Avatar.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import { LucideIcon, User } from 'lucide-react';
 import './Avatar.scss';
 
 interface AvatarProps {
-  children?: React.ReactNode;
+  icon?: LucideIcon;
   image?: string;
   size?: 'small' | 'medium' | 'large' | 'xl';
   color?: 'primary' | 'secondary' | 'accent' | 'gray';
@@ -14,7 +15,7 @@ interface AvatarProps {
 }
 
 const Avatar: React.FC<AvatarProps> = ({ 
-  children,
+  icon: Icon = User,
   image,
   size = 'medium',
   color = 'primary',
@@ -35,6 +36,13 @@ const Avatar: React.FC<AvatarProps> = ({
 
   const handleClick = clickable ? onClick : undefined;
 
+  const iconSizeMap = {
+    small: 14,
+    medium: 18,
+    large: 24,
+    xl: 32
+  };
+
   return (
     <div 
       className={avatarClassName} 
@@ -45,7 +53,7 @@ const Avatar: React.FC<AvatarProps> = ({
       {image ? (
         <img src={image} alt={alt} className="ds-avatar__image" />
       ) : (
-        children
+        <Icon size={iconSizeMap[size]} />
       )}
       {status && (
         <div className={`ds-avatar__status ds-avatar__status--${status}`} />

--- a/src/components/CommentSheet/CommentSheet.tsx
+++ b/src/components/CommentSheet/CommentSheet.tsx
@@ -208,9 +208,7 @@ const CommentSheet: React.FC<CommentSheetProps> = ({
                     size="small"
                     color="secondary"
                     className="ds-comment__avatar"
-                  >
-                    {comment.initial}
-                  </Avatar>
+                  />
 
                   <div className="ds-comment__content-wrapper">
                     <div className="ds-comment__author">{comment.author}</div>
@@ -265,9 +263,7 @@ const CommentSheet: React.FC<CommentSheetProps> = ({
           )}
 
           <div className="ds-comment-sheet__input-wrapper">
-            <Avatar size="medium" color="primary">
-              나
-            </Avatar>
+            <Avatar size="medium" color="primary" />
 
             <div className="ds-comment-sheet__input-group">
               <input

--- a/src/components/FeedCard/FeedCard.tsx
+++ b/src/components/FeedCard/FeedCard.tsx
@@ -5,7 +5,6 @@ import './FeedCard.scss';
 
 interface FeedCardProps {
   authorName?: string;
-  authorInitial?: string;
   timeAgo?: string;
   title?: string;
   content?: string;
@@ -26,7 +25,6 @@ interface FeedCardProps {
 
 const FeedCard = forwardRef<HTMLDivElement, FeedCardProps>(({ 
   authorName = '작성자',
-  authorInitial = '작',
   timeAgo = '방금 전',
   title = '맛집 후기',
   content = '정말 맛있었어요!',
@@ -57,9 +55,7 @@ const FeedCard = forwardRef<HTMLDivElement, FeedCardProps>(({
           size="medium" 
           color="secondary" 
           className="ds-feed-card__avatar"
-        >
-          {authorInitial}
-        </Avatar>
+        />
         <div className="ds-feed-card__author-info">
           <div className="ds-feed-card__author">{authorName}</div>
           <div className="ds-feed-card__time">{timeAgo}</div>


### PR DESCRIPTION
## 📝 변경 사항

### 주요 변경
- 텍스트 이니셜 대신 lucide-react 아이콘 사용 (기본: User 아이콘)
- 강한 그라데이션 제거, 부드러운 단색 배경 적용
- 기존 디자인 시스템의 회색 팔레트 활용

### 세부 사항
- **Avatar 컴포넌트**: `icon` prop 추가로 다양한 아이콘 선택 가능
- **색상 개선**: 
  - Primary: 연한 회색 배경 + 진한 아이콘
  - Secondary: 거의 흰색 배경 + 중간 회색 아이콘
  - Accent: 연한 베이지 배경 + 골드 아이콘
  - Gray: 회색 배경 + 진한 회색 아이콘
- **관련 컴포넌트 수정**: CommentSheet, FeedCard의 Avatar 사용 부분 업데이트

## ✅ 테스트 체크리스트
- [ ] 스토리북에서 모든 Avatar 변형 확인
- [ ] CommentSheet에서 아바타 표시 확인
- [ ] FeedCard에서 아바타 표시 확인
- [ ] 다양한 아이콘 옵션 동작 확인

## 📸 스크린샷
스토리북에서 확인 가능합니다.

🤖 Generated with [Claude Code](https://claude.ai/code)